### PR TITLE
Add binding of configuration values

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ libraryDependencies ++= {
 
         "com.typesafe.akka" %% "akka-actor" % akkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Runtime,
+        "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
 
         "org.scalatest" %% "scalatest" % "2.2.5" % Test,
         "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test

--- a/src/main/scala/com/rxthings/di/NamedConfigModule.scala
+++ b/src/main/scala/com/rxthings/di/NamedConfigModule.scala
@@ -1,0 +1,48 @@
+package com.rxthings.di
+
+
+import com.typesafe.config.{ConfigValue, Config}
+import com.typesafe.config.ConfigValueType._
+import com.typesafe.scalalogging.LazyLogging
+import net.codingwell.scalaguice.ScalaModule
+
+import scala.collection.JavaConversions._
+
+/**
+ * Bind Config values as @Named(path)
+ */
+object NamedConfigModule {
+  def apply(config: Config) = new NamedConfigModule(config)
+}
+
+class NamedConfigModule private(config: Config) extends ScalaModule with LazyLogging {
+  def configure(): Unit = {
+    config.entrySet.foreach { e =>
+      val k = e.getKey
+      val v = e.getValue
+      v.valueType() match {
+        case NUMBER =>
+          logger.trace("binding NUMBER value; [{}] -> [{}]", k, v)
+          val num = v.unwrapped().asInstanceOf[Number]
+          bind[Number].annotatedWithName(k).toInstance(num)
+          bind[Double].annotatedWithName(k).toInstance(num.doubleValue())
+          bind[Long].annotatedWithName(k).toInstance(num.longValue())
+          bind[Int].annotatedWithName(k).toInstance(num.intValue())
+        case BOOLEAN =>
+          logger.trace("binding BOOLEAN value; [{}] -> [{}]", k, v)
+          bind[Boolean].annotatedWithName(k).toInstance(unwrap(v))
+        case STRING =>
+          logger.trace("binding STRING value; [{}] -> [{}]", k, v)
+          bind[String].annotatedWithName(k).toInstance(unwrap(v))
+        case OBJECT =>
+          logger.warn("Config OBJECT values are not supported, [{}]", k)
+        case LIST =>
+          logger.warn("Config List values are not supported, [{}]", k)
+        case NULL =>
+          logger.warn("Config Null values are not supported, [{}]", k)
+      }
+    }
+  }
+
+  def unwrap[T](v: ConfigValue): T = v.unwrapped().asInstanceOf[T]
+}

--- a/src/main/scala/com/rxthings/di/package.scala
+++ b/src/main/scala/com/rxthings/di/package.scala
@@ -42,7 +42,10 @@ package object di {
      * [[com.google.inject.Module]] that provides the application [[Config]]
      */
     class ConfigModule(cfg: Config) extends ScalaModule {
-        def configure(): Unit = bind[Config].toInstance(cfg)
+        def configure(): Unit = {
+            bind[Config].toInstance(cfg)
+            install(NamedConfigModule(cfg))
+        }
     }
 
     //\\ implicits //\\

--- a/src/test/scala/com/rxthings/di/NamedConfigSpec.scala
+++ b/src/test/scala/com/rxthings/di/NamedConfigSpec.scala
@@ -1,0 +1,127 @@
+package com.rxthings.di
+
+import com.google.inject.Guice
+import com.google.inject.name.Names
+import com.typesafe.config.{ConfigValueFactory, Config, ConfigFactory}
+import net.codingwell.scalaguice.InjectorExtensions._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.Random
+
+/**
+ * validate the binding of Config values by their key name
+ */
+class NamedConfigSpec extends WordSpec with Matchers {
+  import NamedConfigSpec._
+
+  "string bindings" should {
+    "be bound by name" in {
+      val (k, v) = rkey() -> rkey()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[String](Names.named(k)) shouldBe v
+    }
+
+    "not be bound without name" in {
+      val (k, v) = rkey() -> Random.nextBoolean()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.existingBinding[String] should not be defined
+    }
+  }
+
+  "int bindings" should {
+    "be bound by name" in {
+      val (k, v) = rkey() -> Random.nextInt()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Int](Names.named(k)) shouldBe v
+    }
+
+    "not be bound without name" in {
+      val (k, v) = rkey() -> Random.nextBoolean()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.existingBinding[Int] should not be defined
+    }
+
+    "be bound to Number with name" in {
+      val (k, v) = rkey() -> Random.nextInt()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Number](Names.named(k)) shouldBe v
+    }
+  }
+
+  "double bindings" should {
+    "be bound by name" in {
+      val (k, v) = rkey() -> Random.nextDouble()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Double](Names.named(k)) shouldBe v
+    }
+
+    "not be bound without name" in {
+      val (k, v) = rkey() -> Random.nextBoolean()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.existingBinding[Double] should not be defined
+    }
+
+    "be bound to Number with name" in {
+      val (k, v) = rkey() -> Random.nextInt()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Number](Names.named(k)) shouldBe v
+    }
+  }
+
+  "long bindings" should {
+    "be bound by name" in {
+      val (k, v) = rkey() -> Random.nextLong()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Long](Names.named(k)) shouldBe v
+    }
+
+    "not be bound without name" in {
+      val (k, v) = rkey() -> Random.nextBoolean()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.existingBinding[Long] should not be defined
+    }
+
+    "be bound to Number with name" in {
+      val (k, v) = rkey() -> Random.nextInt()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Number](Names.named(k)) shouldBe v
+    }
+  }
+
+  "boolean bindings" should {
+    "be bound by name" in {
+      val (k, v) = rkey() -> Random.nextBoolean()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Boolean](Names.named(k)) shouldBe v
+    }
+
+    "not be bound without name" in {
+      val (k, v) = rkey() -> Random.nextBoolean()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.existingBinding[Boolean] should not be defined
+    }
+
+    "be bound to Number with name" in {
+      val (k, v) = rkey() -> Random.nextInt()
+      val inj = Guice.createInjector(NamedConfigSpec(k, v))
+      inj.instance[Number](Names.named(k)) shouldBe v
+    }
+  }
+}
+
+object NamedConfigSpec {
+  def apply[T](k: String, v: T): NamedConfigModule = {
+    val cfg = ConfigFactory.parseString(s"$k=${v.toString}")
+    NamedConfigModule(cfg)
+  }
+
+  def config[T](k: String, v: T): NamedConfigModule = {
+    import scala.collection.JavaConversions._
+    //val cfg = ConfigFactory.empty().withValue(k, ConfigValueFactory.fromMap(Map(k -> v.toString)))
+    val cfg = ConfigFactory.parseMap(Map(k -> ConfigValueFactory.fromMap(Map(k -> v.toString, "x" -> "y"))))
+    NamedConfigModule(cfg)
+  }
+
+  // random key string
+  def rkey() = Random.alphanumeric.take(10).mkString
+}


### PR DESCRIPTION
When cfg binding is enabled the values from the Config will be mapped to `@Named` annotations #6