### PR TITLE
Enable cross-building for Scala 2.11 and 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 
 scala:
+   - 2.11.8
    - 2.12.1
-
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 
+before_install:
+ - chmod +x scripts/travis.sh
+
 scala:
    - 2.11.8
    - 2.12.1
@@ -7,4 +10,4 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test updateImpactSubmit
+  - "scripts/travis.sh"

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ name := "akka-injects"
 version := "0.7-SNAPSHOT"
 licenses +=("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
+crossScalaVersions := Seq("2.11.8", "2.12.1")
+
 scalaVersion := "2.12.1"
 
 scalacOptions ++= Seq(
@@ -21,13 +23,17 @@ scalacOptions ++= Seq(
     "-Xlint:_"
 )
 
+scalacOptions in (Compile, doc) ++= Seq(
+    "-no-link-warnings" // Suppresses problems with Scaladoc links
+)
+
 resolvers ++= Seq(
     "jw3 at bintray" at "https://dl.bintray.com/jw3/maven",
     Resolver.jcenterRepo
 )
 
 libraryDependencies ++= {
-    val akkaVersion = "2.4.16"
+    val akkaVersion = "2.5.0"
     val scalatestVersion = "3.0.0"
 
     Seq(

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,1 @@
+if [ -z ${UPDATEIMPACT_API_KEY} ]; then sbt ++$TRAVIS_SCALA_VERSION test; else sbt ++$TRAVIS_SCALA_VERSION test updateImpactSubmit; fi

--- a/src/main/scala/com/rxthings/di/InjectExt.scala
+++ b/src/main/scala/com/rxthings/di/InjectExt.scala
@@ -20,7 +20,10 @@ import scala.collection.mutable
 class InjectExtImpl(val injector: Injector) extends Extension
 
 object InjectExt extends ExtensionId[InjectExtImpl] with ExtensionIdProvider with InjectExtBuilder {
-  private val manualModules: ThreadLocal[mutable.Set[Module]] = ThreadLocal.withInitial(() ⇒ mutable.Set[Module]())
+  private val manualModules: ThreadLocal[mutable.Set[Module]] = ThreadLocal.withInitial(
+    new java.util.function.Supplier[mutable.Set[Module]] {
+      override def get(): mutable.Set[Module] = mutable.Set[Module]()
+  })
 
   /**
    * Manually add modules to the injector


### PR DESCRIPTION
Also bumped Akka version to 2.5.0. Modified Travis script to run tests against both supported Scala versions and not to run UpdateImpact when its API key is not set. Related to #21 .