### PR TITLE
Remove implicit conversion ActorContext -> ActorSystem

### DIFF
--- a/src/main/scala/com/rxthings/di/package.scala
+++ b/src/main/scala/com/rxthings/di/package.scala
@@ -44,7 +44,6 @@ package object di {
   implicit def standardBuilder2builtOpt[T](builder: InjectionBuilder[T]): Option[T] = builder.optional
   implicit def actorBuilder2actorRefOpt[T <: Actor](builder: ActorInjectionBuilder[T]): Option[ActorRef] = builder.optional
   implicit def actorSystem2injectorProvider(implicit sys: ActorSystem): InjectorProvider = () => InjectExt(sys).injector
-  implicit def actorContext2actorSystem(implicit ctx: ActorContext): ActorSystem = ctx.system
 
   //\\ internals //\\
   private def requireNonNull(o: Any, msg: => Any): Unit = require(o != null, msg)

--- a/src/test/scala/com/rxthings/di/ExampleOfTestingSpec.scala
+++ b/src/test/scala/com/rxthings/di/ExampleOfTestingSpec.scala
@@ -19,6 +19,7 @@ class ExampleOfTestingSpec extends InjectSpec with Matchers {
 }
 
 class InjectedActor extends NopActor {
+  import context._
   val name: String = inject[String] annotated "actor.name"
 }
 

--- a/src/test/scala/com/rxthings/di/InjectActorSpec.scala
+++ b/src/test/scala/com/rxthings/di/InjectActorSpec.scala
@@ -37,6 +37,7 @@ object InjectActorSpec {
   class AnActor extends IAnActor
 
   class AnActorWithInjects extends NopActor {
+    import context._
     val injected: String = inject[String]
   }
 


### PR DESCRIPTION
This aligns akka-inject API with other Akka projects by requiring user
to bring in an implicit instance of `ActorSystem` into scope. It also
resolves the conflict between `import context._` and `import
com.rxthings.di._` when `inject` is used inside Actors. Related to #27.